### PR TITLE
Fix sqlite3 dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,4 @@ gemspec
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.0'
 gem 'rubocop', '~> 1.21'
-gem 'sqlite3'
+gem 'sqlite3', '~> 1.4'


### PR DESCRIPTION
Fix https://github.com/willnet/save_chain_inspector/actions/runs/10131033127/job/28013175659#step:4:38

```
An error occurred while loading spec_helper. - Did you mean?
                    rspec ./spec/spec_helper.rb

Failure/Error: ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')

LoadError:
  Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.2-x86_64-linux-gnu. Make sure all dependencies are added to Gemfile.
# ./vendor/bundle/ruby/3.3.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/sqlite3_adapter.rb:14:in `<top (required)>'
# ./vendor/bundle/ruby/3.3.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract/connection_handler.rb:333:in `resolve_pool_config'
# ./vendor/bundle/ruby/3.3.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract/connection_handler.rb:134:in `establish_connection'
# ./vendor/bundle/ruby/3.3.0/gems/activerecord-7.1.3.4/lib/active_record/connection_handling.rb:53:in `establish_connection'
# ./spec/models.rb:6:in `<top (required)>'
# ./spec/spec_helper.rb:4:in `require_relative'
# ./spec/spec_helper.rb:4:in `<top (required)>'
# ------------------
# --- Caused by: ---
# Gem::LoadError:
#   can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.2-x86_64-linux-gnu. Make sure all dependencies are added to Gemfile.
#   ./vendor/bundle/ruby/3.3.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/sqlite3_adapter.rb:14:in `<top (required)>'
```
