### PR TITLE
Fixed an incorrect guard clause condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,20 @@ end
 
 ```
 Post#save start
- Post#autosave_associated_records_for_comments start
-   Comment#save start
-     Comment#before_save start
-       Comment#autosave_associated_records_for_post start
-       Comment#autosave_associated_records_for_post end
-     Comment#before_save end
-     Comment#after_create start
-     Comment#after_create end
-   Comment#save end
- Post#autosave_associated_records_for_comments end
+  Post#before_save start
+  Post#before_save end
+  Post#after_create start
+    Post#autosave_associated_records_for_comments start
+      Comment#save start
+        Comment#before_save start
+          Comment#autosave_associated_records_for_post start
+          Comment#autosave_associated_records_for_post end
+        Comment#before_save end
+        Comment#after_create start
+        Comment#after_create end
+      Comment#save end
+    Post#autosave_associated_records_for_comments end
+  Post#after_create end
 Post#save end
 ```
 

--- a/lib/save_chain_inspector.rb
+++ b/lib/save_chain_inspector.rb
@@ -20,9 +20,9 @@ class SaveChainInspector # rubocop:disable Metrics/ClassLength, Style/Documentat
   def initialize
     ActiveRecord::Base.descendants.each do |klass|
       next if klass.abstract_class
-      next if @save_chain_inspector_initialized
+      next if klass.instance_variable_get(:@save_chain_inspector_initialized)
 
-      @save_chain_inspector_initialized = true
+      klass.instance_variable_set(:@save_chain_inspector_initialized, true)
       add_hooks(klass)
     end
   end

--- a/spec/save_chain_inspector_spec.rb
+++ b/spec/save_chain_inspector_spec.rb
@@ -12,16 +12,20 @@ RSpec.describe SaveChainInspector do
       end
     end.to output(<<~OUTPUT).to_stdout
       Post#save start
-        Post#autosave_associated_records_for_comments start
-          Comment#save start
-            Comment#before_save start
-              Comment#autosave_associated_records_for_post start
-              Comment#autosave_associated_records_for_post end
-            Comment#before_save end
-            Comment#after_create start
-            Comment#after_create end
-          Comment#save end
-        Post#autosave_associated_records_for_comments end
+        Post#before_save start
+        Post#before_save end
+        Post#after_create start
+          Post#autosave_associated_records_for_comments start
+            Comment#save start
+              Comment#before_save start
+                Comment#autosave_associated_records_for_post start
+                Comment#autosave_associated_records_for_post end
+              Comment#before_save end
+              Comment#after_create start
+              Comment#after_create end
+            Comment#save end
+          Post#autosave_associated_records_for_comments end
+        Post#after_create end
       Post#save end
     OUTPUT
   end


### PR DESCRIPTION
Previously, a flag was used to prevent setting the same hook more than once, but it was set in the wrong context, resulting in unexpected output.
