### PR TITLE
Fix the issue where the indentation became negative

### DIFF
--- a/lib/save_chain_inspector.rb
+++ b/lib/save_chain_inspector.rb
@@ -23,7 +23,7 @@ class SaveChainInspector # rubocop:disable Metrics/ClassLength, Style/Documentat
     end
 
     def decrement_indent
-      self.indent_count -= 1
+      self.indent_count -= 1 if indent_count.positive?
     end
   end
 


### PR DESCRIPTION
We haven't found a simple way to reproduce this issue with test code, but running the following code results in a negative indentation level and an error.

https://gist.github.com/willnet/e4621076bbaa1a29efda6f74f5343e0f

```
Error:
BugTest#test_upload_and_download:
ArgumentError: negative argument
    /Users/willnet/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/save_chain_inspector-0.1.1/lib/save_chain_inspector.rb:121:in `*'
    /Users/willnet/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/save_chain_inspector-0.1.1/lib/save_chain_inspector.rb:121:in `block in trace'
    /Users/willnet/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/activerecord-7.0.8.4/lib/active_record/transactions.rb:303:in `save!'
    /Users/willnet/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/activerecord-7.0.8.4/lib/active_record/suppressor.rb:54:in `save!'
    hoge.rb:74:in `block in test_upload_and_download'
    /Users/willnet/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/save_chain_inspector-0.1.1/lib/save_chain_inspector.rb:104:in `call'
    /Users/willnet/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/save_chain_inspector-0.1.1/lib/save_chain_inspector.rb:15:in `start'
    hoge.rb:73:in `test_upload_and_download'
```

Fix the issue by ensuring the indentation does not become negative.
