### PR TITLE
Show model save callbacks in inspector logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,21 @@ end
 
 ```
 Post#save start
-  Post#before_save start/end
+  Post#prepare_post start/end
+  Post#before_save start
+    Post#normalize_post start/end
+  Post#before_save end
   Post#after_create start
     Post#autosave_associated_records_for_comments start
       Comment#save start
         Comment#before_save start
           Comment#autosave_associated_records_for_post start/end
+          Comment#normalize_comment start/end
         Comment#before_save end
         Comment#after_create start/end
       Comment#save end
     Post#autosave_associated_records_for_comments end
+    Post#notify_created start/end
   Post#after_create end
 Post#save end
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,33 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
 `SaveChainInspector.start` takes a block. It outputs the execution order of the save chain to the standard output by default.
 
-```ruby      
+For example, given models like these:
+
+```ruby
+class Post < ApplicationRecord
+  has_many :comments
+
+  before_validation :prepare_post
+  before_save :normalize_post
+  after_create :notify_created
+
+  def prepare_post; end
+
+  def normalize_post; end
+
+  def notify_created; end
+end
+
+class Comment < ApplicationRecord
+  belongs_to :post
+
+  before_save :normalize_comment
+
+  def normalize_comment; end
+end
+```
+
+```ruby
 SaveChainInspector.start do
   post = Post.new
   post.comments.build

--- a/lib/save_chain_inspector.rb
+++ b/lib/save_chain_inspector.rb
@@ -4,6 +4,78 @@ require_relative 'save_chain_inspector/version'
 
 class SaveChainInspector # rubocop:disable Metrics/ClassLength, Style/Documentation
   SAVE_METHODS = %i[save save!].freeze
+  SAVE_CALLBACK_NAMES = %i[validation save create update].freeze
+  CALLBACK_KINDS = %i[before after around].freeze
+  INTERNAL_CALLBACK_FILTER_PATTERNS = [
+    /\Aautosave_associated_records_for_/,
+    /\A_ensure_no_duplicate_errors\z/,
+    /\Anormalize_changed_in_place_attributes\z/,
+    /\Aaround_save_collection_association\z/
+  ].freeze
+  INTERNAL_GEM_NAMES = %w[activerecord activemodel activesupport].freeze
+
+  class CallbackLogger # :nodoc:
+    CALLBACK_METHOD_PATTERN = /\A(?:before|after|around)_(?:validation|save|create|update)\z/
+
+    def initialize(callback)
+      @callback = callback
+      @filter = callback.filter
+      @label = callback_label(@filter)
+    end
+
+    def self.wraps?(filter)
+      filter.is_a?(self)
+    end
+
+    def method_missing(method_name, target, *_args, &block)
+      return super unless callback_method?(method_name) && target
+
+      call_with_logging(target, &block)
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      callback_method?(method_name) || super
+    end
+
+    private
+
+    def callback_method?(method_name)
+      method_name.to_s.match?(CALLBACK_METHOD_PATTERN)
+    end
+
+    def call_with_logging(target, &block)
+      logged = SaveChainInspector.enable
+      return call_original(target, &block) unless logged
+
+      label = "#{target.class}##{@label}"
+      SaveChainInspector.log_start(label)
+      call_original(target, &block)
+    ensure
+      SaveChainInspector.log_end(label) if logged
+    end
+
+    def call_original(target, &block)
+      ActiveSupport::Callbacks::CallTemplate.build(@filter, @callback).make_lambda.call(target, nil, &block)
+    end
+
+    def callback_label(filter)
+      case filter
+      when Symbol
+        filter
+      when Proc
+        block_callback_label(filter)
+      else
+        filter.class.name || filter.class.to_s
+      end
+    end
+
+    def block_callback_label(filter)
+      source_location = filter.source_location
+      return 'block_callback' unless source_location
+
+      "block_callback(#{source_location[0]}:#{source_location[1]})"
+    end
+  end
 
   class << self
     attr_accessor :indent_count, :enable, :pending_start, :output
@@ -98,11 +170,108 @@ class SaveChainInspector # rubocop:disable Metrics/ClassLength, Style/Documentat
       next if klass.instance_variable_get(:@save_chain_inspector_initialized)
 
       klass.instance_variable_set(:@save_chain_inspector_initialized, true)
+      instrument_model_callbacks(klass)
       add_hooks(klass)
     end
   end
 
   attr_accessor :last_call_method, :last_call_class, :last_return_method, :last_return_class
+
+  def instrument_model_callbacks(klass)
+    SAVE_CALLBACK_NAMES.each do |callback_name|
+      chain = klass.send(:get_callbacks, callback_name)
+      next if chain.nil? || chain.empty?
+
+      instrumented_chain = chain.dup
+      chain.each do |callback|
+        next unless instrumentable_callback?(klass, callback)
+
+        replace_callback(instrumented_chain, callback)
+      end
+      klass.send(:set_callbacks, callback_name, instrumented_chain)
+    end
+  end
+
+  def instrumentable_callback?(klass, callback)
+    CALLBACK_KINDS.include?(callback.kind) &&
+      !CallbackLogger.wraps?(callback.filter) &&
+      !internal_callback?(klass, callback)
+  end
+
+  def replace_callback(chain, callback)
+    index = chain.index(callback)
+    return unless index
+
+    wrapped_callback = ActiveSupport::Callbacks::Callback.build(
+      chain,
+      CallbackLogger.new(callback),
+      callback.kind,
+      callback_options(callback)
+    )
+    chain.delete(callback)
+    chain.insert(index, wrapped_callback)
+  end
+
+  def callback_options(callback)
+    {
+      if: callback.instance_variable_get(:@if),
+      unless: callback.instance_variable_get(:@unless)
+    }
+  end
+
+  def internal_callback?(klass, callback)
+    filter = callback.filter
+    internal_callback_filter_name?(filter) || rails_internal_callback?(klass, callback)
+  end
+
+  def internal_callback_filter_name?(filter)
+    return false unless filter.is_a?(Symbol) || filter.is_a?(String)
+
+    INTERNAL_CALLBACK_FILTER_PATTERNS.any? { |pattern| filter.to_s.match?(pattern) }
+  end
+
+  def rails_internal_callback?(klass, callback)
+    source_location = callback_source_location(klass, callback)
+    source_location && internal_gem_source?(source_location[0])
+  end
+
+  def callback_source_location(klass, callback)
+    source_location_for_callback_filter(klass, callback)
+  rescue NameError
+    nil
+  end
+
+  def source_location_for_callback_filter(klass, callback)
+    filter = callback.filter
+    case filter
+    when Symbol
+      symbol_callback_source_location(klass, filter)
+    when Proc
+      filter.source_location
+    else
+      object_callback_source_location(callback)
+    end
+  end
+
+  def symbol_callback_source_location(klass, filter)
+    klass.instance_method(filter).source_location
+  end
+
+  def object_callback_source_location(callback)
+    method_name = callback.current_scopes.join('_').to_sym
+    callback.filter.method(method_name).source_location
+  rescue NameError
+    nil
+  end
+
+  def internal_gem_source?(path)
+    return false unless path
+
+    INTERNAL_GEM_NAMES.any? do |gem_name|
+      gem_path = Gem.loaded_specs[gem_name]&.full_gem_path
+      gem_path && path.start_with?(gem_path)
+    end
+  end
 
   def add_hooks(klass) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     klass.before_save(prepend: true) do |model|

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -10,6 +10,7 @@ ActiveRecord::Schema.define do
   create_table :comments, force: true do |t|
     t.bigint :post_id
   end
+  create_table :callback_option_records, force: true
 end
 
 class Post < ActiveRecord::Base
@@ -35,4 +36,35 @@ class Comment < ActiveRecord::Base
   before_save :normalize_comment
 
   def normalize_comment; end
+end
+
+class CallbackOptionRecord < ActiveRecord::Base
+  class << self
+    def events
+      @events ||= []
+    end
+  end
+
+  before_validation :create_only_validation, on: :create
+  before_save :prepended_save, prepend: true
+  before_save :appended_save
+  around_save :around_save_callback
+
+  def create_only_validation
+    self.class.events << :create_only_validation
+  end
+
+  def prepended_save
+    self.class.events << :prepended_save
+  end
+
+  def appended_save
+    self.class.events << :appended_save
+  end
+
+  def around_save_callback
+    self.class.events << :around_before
+    yield
+    self.class.events << :around_after
+  end
 end

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -14,8 +14,25 @@ end
 
 class Post < ActiveRecord::Base
   has_many :comments
+
+  before_validation :prepare_post
+  before_save :normalize_post
+  before_save :skipped_post_callback, if: -> { false }
+  after_create :notify_created
+
+  def prepare_post; end
+
+  def normalize_post; end
+
+  def skipped_post_callback; end
+
+  def notify_created; end
 end
 
 class Comment < ActiveRecord::Base
   belongs_to :post
+
+  before_save :normalize_comment
+
+  def normalize_comment; end
 end

--- a/spec/save_chain_inspector_spec.rb
+++ b/spec/save_chain_inspector_spec.rb
@@ -37,6 +37,36 @@ RSpec.describe SaveChainInspector do
     end.not_to output(/skipped_post_callback/).to_stdout
   end
 
+  it 'preserves callback conditions derived from on options' do
+    string_io = StringIO.new
+    CallbackOptionRecord.events.clear
+
+    SaveChainInspector.start(to: string_io) do
+      CallbackOptionRecord.create!
+    end
+
+    expect(string_io.string).to include('CallbackOptionRecord#create_only_validation start/end')
+    expect(CallbackOptionRecord.events).to include(:create_only_validation)
+  end
+
+  it 'preserves callback conditions and order while wrapping callbacks' do
+    record = CallbackOptionRecord.create!
+    string_io = StringIO.new
+    CallbackOptionRecord.events.clear
+
+    SaveChainInspector.start(to: string_io) do
+      record.save!
+    end
+
+    expect(string_io.string).not_to include('CallbackOptionRecord#create_only_validation')
+    expect(string_io.string).to match(
+      %r{CallbackOptionRecord#prepended_save start/end.*CallbackOptionRecord#appended_save start/end}m
+    )
+    expect(string_io.string).to include('CallbackOptionRecord#around_save_callback start')
+    expect(string_io.string).to include('CallbackOptionRecord#around_save_callback end')
+    expect(CallbackOptionRecord.events).to eq(%i[prepended_save appended_save around_before around_after])
+  end
+
   it 'writes logs inside the block' do
     expect do
       SaveChainInspector.start do

--- a/spec/save_chain_inspector_spec.rb
+++ b/spec/save_chain_inspector_spec.rb
@@ -9,19 +9,32 @@ RSpec.describe SaveChainInspector do
   let(:expected_output) do
     <<~OUTPUT
       Post#save start
-        Post#before_save start/end
+        Post#prepare_post start/end
+        Post#before_save start
+          Post#normalize_post start/end
+        Post#before_save end
         Post#after_create start
           Post#autosave_associated_records_for_comments start
             Comment#save start
               Comment#before_save start
                 Comment#autosave_associated_records_for_post start/end
+                Comment#normalize_comment start/end
               Comment#before_save end
               Comment#after_create start/end
             Comment#save end
           Post#autosave_associated_records_for_comments end
+          Post#notify_created start/end
         Post#after_create end
       Post#save end
     OUTPUT
+  end
+
+  it "doesn't write logs for callbacks whose condition is false" do
+    expect do
+      SaveChainInspector.start do
+        Post.create
+      end
+    end.not_to output(/skipped_post_callback/).to_stdout
   end
 
   it 'writes logs inside the block' do


### PR DESCRIPTION
The inspector previously showed the outer save flow, autosave calls, and broad lifecycle hooks, but user-defined model callbacks inside those phases were mostly invisible. That made the output less useful when debugging save chains where before_validation, before_save, or after_create callbacks mutate records or trigger additional work.

This change wraps Active Support save-related callbacks so application callbacks are logged in the same tree as save/autosave events. It keeps callback conditions intact, filters Rails/internal callback noise, and routes callback logs through the existing output abstraction so the configurable target and collapsed start/end formatting added on main continue to apply.

This PR exists to make SaveChainInspector explain the callback-level reasons behind a save chain, not only the model-to-model save order. No issue is linked. I considered logging every callback, but that would duplicate Rails internals and autosave hooks already represented by the TracePoint-based output, so the implementation limits the new logging to instrumentable application callbacks.